### PR TITLE
Fixup Invio.Xunit.csproj

### DIFF
--- a/src/Invio.Xunit/BenchmarkTestAttribute.cs
+++ b/src/Invio.Xunit/BenchmarkTestAttribute.cs
@@ -7,6 +7,10 @@ namespace Invio.Xunit {
     /// </summary>
     public sealed class BenchmarkTestAttribute : CategoryTraitAttribute {
 
+        /// <summary>
+        ///   Instantiates a <see cref="CategoryTraitAttribute" /> with a
+        ///   <see cref="CategoryTraitAttribute.Category" /> value of "Benchmark".
+        /// </summary>
         public BenchmarkTestAttribute() : base("Benchmark") { }
 
     }

--- a/src/Invio.Xunit/CategoryTraitAttribute.cs
+++ b/src/Invio.Xunit/CategoryTraitAttribute.cs
@@ -3,6 +3,11 @@ using Xunit.Sdk;
 
 namespace Invio.Xunit {
 
+    /// <summary>
+    ///   A standard representation of a xUnit trait called "Category" that allows
+    ///   developers to create various, statically typed categories to their tests
+    ///   classes, such as "Unit", "Integration", or "Benchmark".
+    /// </summary>
     [TraitDiscoverer("Invio.Xunit.CategoryTraitDiscoverer", "Invio.Xunit")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
     public abstract class CategoryTraitAttribute : Attribute, ITraitAttribute {
@@ -13,11 +18,17 @@ namespace Invio.Xunit {
         public string Category { get; }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="CategoryTraitAttribute"/> class.
+        ///   Instantiates a new instance of the <see cref="CategoryTraitAttribute"/> class.
         /// </summary>
         /// <param name="category">
         ///   The category of the test (e.g. "Unit", "Integration", or "Benchmark").
         /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="category" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   Thrown when <paramref name="category" /> is empty or whitespace.
+        /// </exception>
         protected CategoryTraitAttribute(string category) {
             if (category == null) {
                 throw new ArgumentNullException(nameof(category));

--- a/src/Invio.Xunit/IntegrationTestAttribute.cs
+++ b/src/Invio.Xunit/IntegrationTestAttribute.cs
@@ -7,7 +7,12 @@ namespace Invio.Xunit {
     /// </summary>
     public sealed class IntegrationTestAttribute : CategoryTraitAttribute {
 
+        /// <summary>
+        ///   Instantiates a <see cref="CategoryTraitAttribute" /> with a
+        ///   <see cref="CategoryTraitAttribute.Category" /> value of "Integration".
+        /// </summary>
         public IntegrationTestAttribute() : base("Integration") { }
+
     }
 
 }

--- a/src/Invio.Xunit/Invio.Xunit.csproj
+++ b/src/Invio.Xunit/Invio.Xunit.csproj
@@ -13,6 +13,7 @@
     <PackageLicenseUrl>https://github.com/invio/Invio.Xunit/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git@github.com:invio/Invio.Xunit</RepositoryUrl>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Invio.Xunit/Invio.Xunit.csproj
+++ b/src/Invio.Xunit/Invio.Xunit.csproj
@@ -6,6 +6,7 @@
     <Authors>Invio Inc &lt;developers@invioinc.com&gt;</Authors>
     <TargetFramework>netstandard1.1</TargetFramework>
     <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Invio.Xunit</AssemblyName>
     <PackageId>Invio.Xunit</PackageId>
     <PackageTags>xunit;test</PackageTags>

--- a/src/Invio.Xunit/UnitTestAttribute.cs
+++ b/src/Invio.Xunit/UnitTestAttribute.cs
@@ -3,10 +3,14 @@ using System;
 namespace Invio.Xunit {
 
     /// <summary>
-    ///   Indicates the test should be testing at the smallest amount
+    ///   Indicates the test should be testing a single "unit" of business logic.
     /// </summary>
     public sealed class UnitTestAttribute : CategoryTraitAttribute {
 
+        /// <summary>
+        ///   Instantiates a <see cref="CategoryTraitAttribute" /> with a
+        ///   <see cref="CategoryTraitAttribute.Category" /> value of "Unit".
+        /// </summary>
         public UnitTestAttribute() : base("Unit") { }
 
     }


### PR DESCRIPTION
- Sets `<IsPackable>true</IsPackable>` on root project, which re-enables the creation of a nuget package that was failing to be created ([here's an example](https://ci.appveyor.com/project/invio/invio-xunit/build/26-efxmlwef#L138)).
- Enabled `<GenerateDocumentationFile>true</GenerateDocumentationFile>` so we get warnings when we fail to put documentation on a public member.